### PR TITLE
Disable pos-tip-hide when pos-tip is not installed.

### DIFF
--- a/pophint.el
+++ b/pophint.el
@@ -871,7 +871,9 @@ USE-POS-TIP is t or nil. If omitted, inherit `pophint:use-pos-tip'."
         (yaxception:finally
           (use-global-map old-global-map)
           (when timer (cancel-timer timer))
-          (pos-tip-hide))))))
+          (when (and pophint:use-pos-tip
+                     (featurep 'pos-tip))
+            (pos-tip-hide)))))))
 
 (defun* pophint--get-read-prompt (&key (count 0)
                                        (actdesc "")


### PR DESCRIPTION
Currently, `pophint-do` does not work well, because `pos-tip-hide` is executed without `pos-tip` package.
I fixed it.
